### PR TITLE
Await task returned by ServerLifecycleManager's Run method.

### DIFF
--- a/Dev/Dev2.Server/Main.cs
+++ b/Dev/Dev2.Server/Main.cs
@@ -18,12 +18,13 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime;
 using System.ServiceProcess;
+using System.Threading.Tasks;
 
 namespace Dev2
 {
     static class EntryPoint
     {
-        static int Main(string[] arguments)
+        static async Task<int> Main(string[] arguments)
         {
             AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
             {
@@ -34,16 +35,16 @@ namespace Dev2
             {
                 using (new MemoryFailPoint(2048))
                 {
-                    return RunMain(arguments);
+                    return await RunMain(arguments);
                 }
             }
             catch (InsufficientMemoryException)
             {
-                return RunMain(arguments);
+                return await RunMain(arguments);
             }
         }
 
-        internal static int RunMain(string[] arguments)
+        internal static async Task<int> RunMain(string[] arguments)
         {
             SetWorkingDirectory();
 
@@ -52,7 +53,7 @@ namespace Dev2
             if (Environment.UserInteractive || (arguments.Any() && arguments[0] == "--interactive"))
             {
                 Dev2Logger.Info("** Starting In Interactive Mode **", GlobalConstants.WarewolfInfo);
-                new ServerLifecycleManager(new ServerEnvironmentPreparer()).Run(new LifeCycleInitializationList());
+                await new ServerLifecycleManager(new ServerEnvironmentPreparer()).Run(new LifeCycleInitializationList());
             }
             else
             {

--- a/Dev/Dev2.Server/ServerLifecycleManager.cs
+++ b/Dev/Dev2.Server/ServerLifecycleManager.cs
@@ -150,9 +150,9 @@ namespace Dev2
         /// </summary>
         /// <param name="initWorkers">Initilization Workers</param>
         /// <returns>A Task that starts up the Warewolf Server.</returns>
-        public Task Run(IEnumerable<IServerLifecycleWorker> initWorkers)
+        public async Task Run(IEnumerable<IServerLifecycleWorker> initWorkers)
         {
-            return Task.Run(() =>
+            await Task.Run(() =>
             {
                 LoadPerformanceCounters();
 

--- a/Dev/Dev2.Server/ServerLifecycleManager.cs
+++ b/Dev/Dev2.Server/ServerLifecycleManager.cs
@@ -150,9 +150,9 @@ namespace Dev2
         /// </summary>
         /// <param name="initWorkers">Initilization Workers</param>
         /// <returns>A Task that starts up the Warewolf Server.</returns>
-        public async Task Run(IEnumerable<IServerLifecycleWorker> initWorkers)
+        public Task Run(IEnumerable<IServerLifecycleWorker> initWorkers)
         {
-            await Task.Run(() =>
+            return Task.Run(() =>
             {
                 LoadPerformanceCounters();
 


### PR DESCRIPTION
Fixes issue created by 039fc2bbba1384e7d572da22e7b04dd01a28f0d9.
The task returned was not awaited, causing the process to exit almost immediately when running interactively.